### PR TITLE
Add a Hide event to allow the implementing component control showing and hiding the modal.

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -23,6 +23,8 @@ class Modal extends Component {
 	 */
 	attached() {
 		this.autoFocus_(this.autoFocus);
+
+		this.addListener('hide', this.defaultHideFn_, true);
 	}
 
 	/**
@@ -38,6 +40,13 @@ class Modal extends Component {
 				element.focus();
 			}
 		}
+	}
+
+	/**
+	 * Run only if no listener calls event.preventDefault().
+	 */
+	defaultHideFn_() {
+		this.visible = false;
 	}
 
 	/**
@@ -81,10 +90,10 @@ class Modal extends Component {
 	}
 
 	/**
-	 * Hides the modal, setting its `visible` state key to false.
+	 * Emits a hide event.
 	 */
 	hide() {
-		this.visible = false;
+		this.emit('hide');
 	}
 
 	/**

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -7,6 +7,8 @@ import templates from './Modal.soy.js';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
 
+const KEY_CODE_ESC = 27;
+
 /**
  * Modal component.
  */
@@ -84,7 +86,7 @@ class Modal extends Component {
 	 * @protected
 	 */
 	handleKeyup_(event) {
-		if (event.keyCode === 27) {
+		if (event.keyCode === KEY_CODE_ESC) {
 			this.hide();
 		}
 	}

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,7 +1,8 @@
 {
   "mocha": true,
   "globals": {
-    "assert": true
+    "assert": true,
+    "sinon": true
   },
   "extends": "../.jshintrc"
 }

--- a/test/Modal.js
+++ b/test/Modal.js
@@ -462,4 +462,25 @@ describe('Modal', function() {
 		modal.show();
 		assert.ok(modal.visible);
 	});
+
+	it('should emit the "hide" event when the hide method is called', function() {
+		var spy = sinon.spy();
+		modal = new Modal({
+			events: {hide: spy},
+			visible: false
+		});
+		modal.hide();
+		assert.ok(spy.called);
+	});
+
+	it('should not set visibility to false on "hide" when preventDefault is called on the hide event', function() {
+		modal = new Modal({
+			events: {
+				hide: event => event.preventDefault()
+			},
+			visible: true
+		});
+		modal.hide();
+		assert.ok(modal.visible);
+	});
 });


### PR DESCRIPTION
The idea behind this pull is that when using soy it doesn't make sense to require a reference to the modal in order to conditionally show and hide it. Rather, you should be able to choose when to render it on the page with an `{if}` statement surrounding the call to render the modal. This is already possible, but what is currently an issue is that the default close button in modal handles it's visibility internally. This pull has modal emit a `hide` event when Hide is called that the implementing component could listen to and therefore handle how it wants to hide the modal. The implementation would look something like this:

```java
{if $modalVisible_}
	{call Modal.render}
		{param events: ['hide': $handleModalHide_] /}
		{param header kind="html"}
			<h2>Modal Header</h2>
		{/param}

		{param body kind="html"}
			<div>{$modalContent_}</div>
		{/param}
	{/call}
{/if}
```

In the javascipt:

```js
handleModalHide_() {
	this.modalVisible_ = false;
}
```

Let me know what you think.