### PR TITLE
Add "dialogClasses" param.

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -212,6 +212,14 @@ Modal.STATE = {
 	},
 
 	/**
+	 * Classes that will be applied to the modal-dialog element.
+	 * @type {string}
+	 */
+	dialogClasses: {
+		validator: core.isString
+	},
+
+	/**
 	 * Content to be placed inside modal footer. Can be either an html string or
 	 * a function that calls incremental-dom to render the footer.
 	 * @type {string|function()}

--- a/src/Modal.soy
+++ b/src/Modal.soy
@@ -6,6 +6,7 @@
 {template .render}
 	{@param? body: html|string}
 	{@param? bodyId: string}
+	{@param? dialogClasses: string}
 	{@param? elementClasses: string}
 	{@param? footer: html|string}
 	{@param? header: html|string}
@@ -17,7 +18,7 @@
 		class="modal{$elementClasses ? ' ' + $elementClasses : ''}"
 		style="display: {$visible ? 'block' : 'none'}">
 		<div
-			class="modal-dialog"
+			class="modal-dialog{$dialogClasses ? ' ' + $dialogClasses : ''}"
 			tabindex="0"
 			role="{$role ? $role : 'dialog'}"
 			aria-labelledby="{$headerId}"

--- a/test/Modal.js
+++ b/test/Modal.js
@@ -483,4 +483,12 @@ describe('Modal', function() {
 		modal.hide();
 		assert.ok(modal.visible);
 	});
+
+	it('should add classes passed to "dialogClasses" to the modal dialog element', function() {
+		modal = new Modal({
+			dialogClasses: 'modal-lg'
+		});
+		var dialog = modal.element.querySelector('.modal-dialog');
+		assert.ok(dialog.classList.contains('modal-lg'));
+	});
 });


### PR DESCRIPTION
Hey guys, the purpose of this pr is to allow classnames to be applied to the `modal-dialog` element. The reason why we need this is because the bootstrap markup, which `metal-modal` is based on, applies classnames to that element to modify different styles. For instance, if you want a wider modal you need to add the class `modal-lg` to the `modal-dialog` element. 

Let me know if you guys have any questions or see anything that should be changed.

@Robert-Frampton @mthadley @bryceosterhaus @brunobasto @jbalsas 