### PR TITLE
Updated HTML syntax to make it compatible with Bootstrap 4

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -16,7 +16,7 @@
 	<script type="text/javascript">
 		window.modal = new metal.Modal({
 			element: '.modal',
-			header: '<h4 class="modal-title">Modal header</h4>',
+			header: '<h4>Modal header</h4>',
 			body: 'One fine body...',
 			footer: '<button type="button" class="btn btn-primary">OK</button>'
 		});

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -179,7 +179,7 @@ class Modal extends Component {
 	 * @protected
 	 */
 	valueOverlayElementFn_() {
-		return dom.buildFragment('<div class="modal-backdrop fade in"></div>').firstChild;
+		return dom.buildFragment('<div class="modal-backdrop fade show"></div>').firstChild;
 	}
 }
 

--- a/src/Modal.soy
+++ b/src/Modal.soy
@@ -26,12 +26,12 @@
 			<div class="modal-content">
 				<header class="modal-header">
 					{if $header}
+						<div class="modal-title" id="{$headerId}">{$header}</div>
 						{if not $noCloseButton}
 							<button type="button" class="close" data-onclick="hide" aria-label="Close">
 								<span aria-hidden="true">×</span>
 							</button>
 						{/if}
-						<div id="{$headerId}">{$header}</div>
 					{/if}
 				</header>
 				<section class="modal-body" id="{$bodyId}" role="document" tabindex="0">


### PR DESCRIPTION
With the current HTML tags used by metal-modal, dialogs are broken with liferay-portal master (using bootstrap 4). The problem is that these new classes are incompatible with bootstrap 3, so maybe a `next` or `bootstrap4` branch should be used for this.

![captura de pantalla de 2017-11-07 09-03-27](https://user-images.githubusercontent.com/800645/32483044-92b5413e-c39a-11e7-98fe-1c4cd1872c90.png)